### PR TITLE
Update to use GHC 9.4.8 to 9.12.1. No fixes to warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/Data/Generics/SYB/WithClass/Basics.hs
+++ b/Data/Generics/SYB/WithClass/Basics.hs
@@ -18,13 +18,10 @@ module Data.Generics.SYB.WithClass.Basics (
 
 ) where
 
-#if MIN_VERSION_base(4,7,0)
 import Data.Typeable hiding (Proxy)
-#else
-import Data.Typeable
-#endif
 
 import Data.Generics.SYB.WithClass.Context
+import Data.Maybe (listToMaybe)
 
 #ifdef __HADDOCK__
 data Proxy
@@ -382,9 +379,7 @@ readConstr dt str =
     -- Traverse list of algebraic datatype constructors
     idx :: [Constr] -> Maybe Constr
     idx cons = let fit = filter ((==) str . showConstr) cons
-                in if fit == []
-                     then Nothing
-                     else Just (head fit)
+                in listToMaybe fit
 
 
 ------------------------------------------------------------------------------

--- a/Data/Generics/SYB/WithClass/Derive.hs
+++ b/Data/Generics/SYB/WithClass/Derive.hs
@@ -268,6 +268,7 @@ typeInfo d
                                    fields = map getField xs
                                    types  = map getType xs
                                in (c, length xs, Just fields, types)
+      
 #if MIN_VERSION_template_haskell(2,17,0)
        varName (PlainTV n _) = n
        varName (KindedTV n _ _) = n

--- a/syb-with-class.cabal
+++ b/syb-with-class.cabal
@@ -1,5 +1,5 @@
 Name:               syb-with-class
-Version:            0.6.1.14
+Version:            0.6.1.15
 License:            BSD3
 License-file:       LICENSE
 Copyright:          2004 - 2008 The University of Glasgow, CWI,
@@ -15,7 +15,7 @@ Description:
     Classes, and Template Haskell code to generate instances, for the
     Scrap Your Boilerplate With Class system.
 Category:           Data
-Tested-With:        GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.2
+Tested-With:        GHC == 9.4.8, GHC == 9.6.6, GHC == 9.8.2, GHC == 9.8.4, GHC == 9.10.1, GHC == 9.12.1
 Build-Type:         Simple
 Cabal-Version:      >= 1.10
 
@@ -25,7 +25,7 @@ source-repository head
 
 Library
     Default-Language: Haskell2010
-    Build-Depends:      base >= 3 && < 5, template-haskell >= 2.4 && < 2.19, bytestring, array, containers
+    Build-Depends:      base >= 3 && < 5, template-haskell >= 2.4 && < 2.30, bytestring, array, containers
     Exposed-modules:
         Data.Generics.SYB.WithClass.Basics
         Data.Generics.SYB.WithClass.Context


### PR DESCRIPTION
There are missing pattern matches for newer TH but I don't know how to fix for the GADT constructors - https://hackage.haskell.org/package/template-haskell-2.23.0.0/docs/Language-Haskell-TH.html#t:Con